### PR TITLE
Global erase function for candies

### DIFF
--- a/Assets/_Game/Script/Candy.cs
+++ b/Assets/_Game/Script/Candy.cs
@@ -1,8 +1,7 @@
 using UnityEngine;
-using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
-public class Candy : MonoBehaviour, IPointerDownHandler
+public class Candy : MonoBehaviour
 {
     Texture2D texture;
     Image image;
@@ -13,10 +12,10 @@ public class Candy : MonoBehaviour, IPointerDownHandler
         image = img;
     }
 
-    public void OnPointerDown(PointerEventData e)
+    public void Erase(Vector2 screenPos, Camera cam)
     {
         RectTransformUtility.ScreenPointToLocalPointInRectangle(
-            (RectTransform)transform, e.position, e.pressEventCamera, out var local);
+            (RectTransform)transform, screenPos, cam, out var local);
 
         Rect rect = image.rectTransform.rect;
         int px = Mathf.RoundToInt((local.x + rect.width * 0.5f) / rect.width * texture.width);

--- a/Assets/_Game/Script/StageManger.cs
+++ b/Assets/_Game/Script/StageManger.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
 
-public class StageManger : MonoBehaviour
+public class StageManger : MonoBehaviour, IPointerDownHandler
 {
     [SerializeField] int width = 500;
     [SerializeField] int height = 300;
@@ -13,6 +14,7 @@ public class StageManger : MonoBehaviour
     [SerializeField] float growDuration = 2f;
 
     Texture2D stageTexture;
+    readonly List<Candy> candies = new List<Candy>();
 
     void Awake()
     {
@@ -65,6 +67,7 @@ public class StageManger : MonoBehaviour
 
         Candy candy = go.GetComponent<Candy>();
         candy.Initialize(tex, img);
+        candies.Add(candy);
 
         StartCoroutine(Grow(img));
     }
@@ -89,5 +92,11 @@ public class StageManger : MonoBehaviour
             yield return null;
         }
         img.fillAmount = 1f;
+    }
+
+    public void OnPointerDown(PointerEventData e)
+    {
+        foreach (var candy in candies)
+            candy.Erase(e.position, e.pressEventCamera);
     }
 }


### PR DESCRIPTION
## Summary
- Move candy erasing logic to a dedicated `Erase` method
- Handle pointer input at the stage level and apply erasing across all candies

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68be8cecf3c083329abba93f043f0c21